### PR TITLE
customize docker plugin

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -19,7 +19,8 @@ file in the Carbyne Stack
 - Graf Johannes (synyx) [info@honda-ri.de](mailto:info@honda-ri.de)
 - Graffi Kalman [Kalman.Graffi@honda-ri.de](mailto:Kalman.Graffi@honda-ri.de)
 - Klenk Timo (synyx) [info@honda-ri.de](mailto:info@honda-ri.de)
-- Matyunin Nikolay [Nikolay.Matyunin@honda-ri.de](mailto:Nikolay.Matyunin@honda-ri.de)
+- Matyunin Nikolay
+  [Nikolay.Matyunin@honda-ri.de](mailto:Nikolay.Matyunin@honda-ri.de)
 - Scherer Petra (synyx) [info@honda-ri.de](mailto:info@honda-ri.de)
 
 ### Robert Bosch GmbH

--- a/amphora-common/src/main/java/io/carbynestack/amphora/common/MultiplicationExchangeObject.java
+++ b/amphora-common/src/main/java/io/carbynestack/amphora/common/MultiplicationExchangeObject.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 import lombok.Value;
 
 /**
- * A dedicated object used to share a single party's interim values from a MPC multiplication with
+ * A dedicated object used to share a single party's interim values from an MPC multiplication with
  * the other participating players of the MPC cluster.
  */
 @Value

--- a/amphora-service/pom.xml
+++ b/amphora-service/pom.xml
@@ -21,6 +21,8 @@
         <!-- skip docker build by default -->
         <dockerfile.skip>true</dockerfile.skip>
         <docker.baseImage>ghcr.io/carbynestack/ubuntu-java-openjre:8-dev</docker.baseImage>
+        <docker.repository>ghcr.io/carbynestack/${project.artifactId}</docker.repository>
+        <docker.tag>${project.version}</docker.tag>
 
         <!-- Plugin versions -->
         <spotify.dockerfile-maven.version>1.4.13</spotify.dockerfile-maven.version>
@@ -278,8 +280,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <repository>ghcr.io/carbynestack/${project.artifactId}</repository>
-                    <tag>${project.version}</tag>
+                    <repository>${docker.repository}</repository>
+                    <tag>${docker.tag}</tag>
                 </configuration>
             </plugin>
         </plugins>

--- a/amphora-service/src/test/java/io/carbynestack/amphora/service/persistence/datastore/MinioSecretShareDataStoreTest.java
+++ b/amphora-service/src/test/java/io/carbynestack/amphora/service/persistence/datastore/MinioSecretShareDataStoreTest.java
@@ -115,7 +115,8 @@ public class MinioSecretShareDataStoreTest {
             AmphoraServiceException.class,
             () -> secretShareDataStore.getSecretShareData(unknownSecretId));
     assertEquals(
-        String.format(GET_DATA_FOR_SECRET_EXCEPTION_MSG, unknownSecretId, "inputStream"), ase.getMessage());
+        String.format(GET_DATA_FOR_SECRET_EXCEPTION_MSG, unknownSecretId, "inputStream"),
+        ase.getMessage());
   }
 
   @SneakyThrows


### PR DESCRIPTION
so we can push to a different registry - e.g. a private one.

Publish Amphora docker iamge to a private registry:

```bash
export AMPHORA_IMAGE_TAG=latest
mvn package dockerfile:push \
 -Ddocker.repository=registry.example.org/carbynestack/amphora-service \
 -Ddocker.tag=$AMPHORA_IMAGE_TAG \
 -Ddockerfile.skip=false
```