### PR TITLE
chore: release  common 0.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "amphora-parent": "0.1.2",
-  "amphora-common": "0.1.0",
+  "amphora-common": "0.1.1",
   "amphora-java-client": "0.1.0",
   "amphora-service": "0.1.0",
   "amphora-service/charts/amphora": "0.1.0"

--- a/amphora-common/CHANGELOG.md
+++ b/amphora-common/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [0.1.1](https://github.com/carbynestack/amphora/compare/common-v0.1.0...common-v0.1.1) (2023-07-27)
+
+
+### Bug Fixes
+
+* **common/java-client/service:** migrate to new parent ([#60](https://github.com/carbynestack/amphora/issues/60)) ([8d1894c](https://github.com/carbynestack/amphora/commit/8d1894c799cf7222ad975875eab0484d4ac7110c))
+* implement release-please process ([#48](https://github.com/carbynestack/amphora/issues/48)) ([1f35ca2](https://github.com/carbynestack/amphora/commit/1f35ca2dfb6624285f691ca3f1e64ddb89426d6b))
+* introduce parent release package ([#52](https://github.com/carbynestack/amphora/issues/52)) ([daa5a69](https://github.com/carbynestack/amphora/commit/daa5a697eb9df8d7844245961666f1ee74f0e2bb))
+* **parent:** introduce parent release package ([ba73fe8](https://github.com/carbynestack/amphora/commit/ba73fe865470052ce2381d81de3017a6bb27e7fe))

--- a/amphora-common/pom.xml
+++ b/amphora-common/pom.xml
@@ -5,12 +5,10 @@
   ~
   ~ SPDX-License-Identifier: Apache-2.0
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>amphora-common</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <parent>
         <groupId>io.carbynestack</groupId>
         <artifactId>amphora-parent</artifactId>


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.1](https://github.com/carbynestack/amphora/compare/common-v0.1.0...common-v0.1.1) (2023-07-27)


### Bug Fixes

* **common/java-client/service:** migrate to new parent ([#60](https://github.com/carbynestack/amphora/issues/60)) ([8d1894c](https://github.com/carbynestack/amphora/commit/8d1894c799cf7222ad975875eab0484d4ac7110c))
* implement release-please process ([#48](https://github.com/carbynestack/amphora/issues/48)) ([1f35ca2](https://github.com/carbynestack/amphora/commit/1f35ca2dfb6624285f691ca3f1e64ddb89426d6b))
* introduce parent release package ([#52](https://github.com/carbynestack/amphora/issues/52)) ([daa5a69](https://github.com/carbynestack/amphora/commit/daa5a697eb9df8d7844245961666f1ee74f0e2bb))
* **parent:** introduce parent release package ([ba73fe8](https://github.com/carbynestack/amphora/commit/ba73fe865470052ce2381d81de3017a6bb27e7fe))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).