### PR TITLE
chore: release  chart 0.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,5 @@
   "amphora-common": "0.1.1",
   "amphora-java-client": "0.1.1",
   "amphora-service": "0.1.1",
-  "amphora-service/charts/amphora": "0.1.0"
+  "amphora-service/charts/amphora": "0.1.1"
 }

--- a/amphora-service/charts/amphora/CHANGELOG.md
+++ b/amphora-service/charts/amphora/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.1](https://github.com/carbynestack/amphora/compare/chart-v0.1.0...chart-v0.1.1) (2023-07-27)
+
+
+### Bug Fixes
+
+* **chart:** trigger release ([#63](https://github.com/carbynestack/amphora/issues/63)) ([fcfb495](https://github.com/carbynestack/amphora/commit/fcfb4953b0f6d70a1a734003572f83b98ff7dbe5))

--- a/amphora-service/charts/amphora/Chart.yaml
+++ b/amphora-service/charts/amphora/Chart.yaml
@@ -1,13 +1,14 @@
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm chart for creating a Carbyne Stack Amphora secret storage and management service.
+description: A Helm chart for creating a Carbyne Stack Amphora secret storage
+  and management service.
 name: amphora
-version: 0.1.0
+version: 0.1.1
 keywords:
-- carbyne stack
-- amphora
+  - carbyne stack
+  - amphora
 home: https://carbynestack.io
 sources:
-- https://github.com/carbynestack/amphora
+  - https://github.com/carbynestack/amphora
 maintainers:
-- name: CarbyneStack.io
+  - name: CarbyneStack.io


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.1](https://github.com/carbynestack/amphora/compare/chart-v0.1.0...chart-v0.1.1) (2023-07-27)


### Bug Fixes

* **chart:** trigger release ([#63](https://github.com/carbynestack/amphora/issues/63)) ([fcfb495](https://github.com/carbynestack/amphora/commit/fcfb4953b0f6d70a1a734003572f83b98ff7dbe5))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).