### PR TITLE
chore: release  parent 0.2.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "amphora-parent": "0.1.2",
+  "amphora-parent": "0.2.0",
   "amphora-common": "0.1.1",
   "amphora-java-client": "0.1.1",
   "amphora-service": "0.1.1",

--- a/amphora-parent/CHANGELOG.md
+++ b/amphora-parent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.0](https://github.com/carbynestack/amphora/compare/parent-v0.1.2...parent-v0.2.0) (2024-10-09)
+
+
+### Features
+
+* **amphora-parent:** upgrade internal dependencies ([#66](https://github.com/carbynestack/amphora/issues/66)) ([fac4666](https://github.com/carbynestack/amphora/commit/fac4666e399a99aee76ed9dcfd850ace1bade0c2))
+
 ## [0.1.2](https://github.com/carbynestack/amphora/compare/parent-v0.1.1...parent-v0.1.2) (2023-07-27)
 
 

--- a/amphora-parent/pom.xml
+++ b/amphora-parent/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>amphora-parent</artifactId>
     <groupId>io.carbynestack</groupId>
-    <version>0.1.2</version>
+    <version>0.2.0</version>
     <packaging>pom</packaging>
     <licenses>
         <license>


### PR DESCRIPTION
:package: Staging a new release
---


## [0.2.0](https://github.com/carbynestack/amphora/compare/parent-v0.1.2...parent-v0.2.0) (2024-10-09)


### Features

* **amphora-parent:** upgrade internal dependencies ([#66](https://github.com/carbynestack/amphora/issues/66)) ([fac4666](https://github.com/carbynestack/amphora/commit/fac4666e399a99aee76ed9dcfd850ace1bade0c2))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).