### PR TITLE
chore: release  service 0.3.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,6 @@
   "amphora-parent": "0.2.0",
   "amphora-common": "0.2.0",
   "amphora-java-client": "0.2.0",
-  "amphora-service": "0.3.0",
+  "amphora-service": "0.3.1",
   "amphora-service/charts/amphora": "0.3.0"
 }

--- a/amphora-service/CHANGELOG.md
+++ b/amphora-service/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.1](https://github.com/carbynestack/amphora/compare/service-v0.3.0...service-v0.3.1) (2025-03-18)
+
+
+### Bug Fixes
+
+* **chart:** fix support for more than 2 parties ([#79](https://github.com/carbynestack/amphora/issues/79)) ([30d4133](https://github.com/carbynestack/amphora/commit/30d4133e44b5706d848d78860131ea663173f2b1))
+
 ## [0.3.0](https://github.com/carbynestack/amphora/compare/service-v0.2.0...service-v0.3.0) (2024-12-17)
 
 

--- a/amphora-service/pom.xml
+++ b/amphora-service/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>amphora-service</artifactId>
     <name>Amphora Service</name>
     <description>Amphora bucket/object store service.</description>
-    <version>0.3.0</version>
+    <version>0.3.1</version>
     <parent>
         <groupId>io.carbynestack</groupId>
         <artifactId>amphora-parent</artifactId>


### PR DESCRIPTION
:package: Staging a new release
---


## [0.3.1](https://github.com/carbynestack/amphora/compare/service-v0.3.0...service-v0.3.1) (2025-03-18)


### Bug Fixes

* **chart:** fix support for more than 2 parties ([#79](https://github.com/carbynestack/amphora/issues/79)) ([30d4133](https://github.com/carbynestack/amphora/commit/30d4133e44b5706d848d78860131ea663173f2b1))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).