### PR TITLE
chore: release  chart 0.3.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,5 @@
   "amphora-common": "0.2.0",
   "amphora-java-client": "0.2.0",
   "amphora-service": "0.3.0",
-  "amphora-service/charts/amphora": "0.3.0"
+  "amphora-service/charts/amphora": "0.3.1"
 }

--- a/amphora-service/charts/amphora/CHANGELOG.md
+++ b/amphora-service/charts/amphora/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.1](https://github.com/carbynestack/amphora/compare/chart-v0.3.0...chart-v0.3.1) (2025-03-18)
+
+
+### Bug Fixes
+
+* **chart:** fix support for more than 2 parties ([#79](https://github.com/carbynestack/amphora/issues/79)) ([30d4133](https://github.com/carbynestack/amphora/commit/30d4133e44b5706d848d78860131ea663173f2b1))
+
 ## [0.3.0](https://github.com/carbynestack/amphora/compare/chart-v0.2.0...chart-v0.3.0) (2024-12-17)
 
 

--- a/amphora-service/charts/amphora/Chart.yaml
+++ b/amphora-service/charts/amphora/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for creating a Carbyne Stack Amphora secret storage
   and management service.
 name: amphora
-version: 0.3.0
+version: 0.3.1
 keywords:
   - carbyne stack
   - amphora


### PR DESCRIPTION
:package: Staging a new release
---


## [0.3.1](https://github.com/carbynestack/amphora/compare/chart-v0.3.0...chart-v0.3.1) (2025-03-18)


### Bug Fixes

* **chart:** fix support for more than 2 parties ([#79](https://github.com/carbynestack/amphora/issues/79)) ([30d4133](https://github.com/carbynestack/amphora/commit/30d4133e44b5706d848d78860131ea663173f2b1))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).